### PR TITLE
Invoke ginkgo with go run instead of local binary

### DIFF
--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -5,12 +5,12 @@ Debug "$(gci env:* | sort-object name | Out-String)"
 Configure-Groot "$env:WINC_TEST_ROOTFS"
 Configure-Winc-Network delete
 
-ginkgo.exe -p -r --race -keep-going --randomize-suites --fail-on-pending --skip-package winc-network,perf --flake-attempts 3
+go run github.com/onsi/ginkgo/v2/ginkgo -p -r --race -keep-going --randomize-suites --fail-on-pending --flake-attempts 3 --skip-package winc-network,perf
 if ($LastExitCode -ne 0) {
   throw "tests failed"
 }
 
-ginkgo.exe -r --race -keep-going --randomize-suites --fail-on-pending --flake-attempts 3 ./integration/perf ./integration/winc-network
+go run github.com/onsi/ginkgo/v2/ginkgo -r --race -keep-going --randomize-suites --fail-on-pending --flake-attempts 3 ./integration/perf ./integration/winc-network
 if ($LastExitCode -ne 0) {
   throw "tests failed"
 }


### PR DESCRIPTION
Fixes:
```
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.9.5
  Mismatched package versions found:
    2.13.0 used by hcs, winc, network, endpoint, firewall, mtu, netinterface, netrules, firewallapplier, netsh, port_allocator, serial, runtime, config, container, hcsprocess, mount, state
```