### PR TITLE
Address issue with staticcheck

### DIFF
--- a/integration/perf/perf_suite_test.go
+++ b/integration/perf/perf_suite_test.go
@@ -2,7 +2,6 @@ package perf_test
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,8 +48,6 @@ var _ = BeforeSuite(func() {
 		present bool
 		err     error
 	)
-
-	rand.Seed(time.Now().UnixNano() + int64(GinkgoParallelProcess()))
 
 	rootfsURI, present = os.LookupEnv("WINC_TEST_ROOTFS")
 	Expect(present).To(BeTrue(), "WINC_TEST_ROOTFS not set")

--- a/integration/winc-network/winc_network_suite_test.go
+++ b/integration/winc-network/winc_network_suite_test.go
@@ -3,7 +3,6 @@ package main_test
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -58,8 +57,6 @@ func TestWincNetwork(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	rand.Seed(time.Now().UnixNano() + int64(GinkgoParallelProcess()))
-
 	var present bool
 	rootfsURI, present = os.LookupEnv("WINC_TEST_ROOTFS")
 	Expect(present).To(BeTrue(), "WINC_TEST_ROOTFS not set")

--- a/integration/winc/winc_suite_test.go
+++ b/integration/winc/winc_suite_test.go
@@ -3,7 +3,6 @@ package main_test
 import (
 	"encoding/json"
 	"fmt"
-	mathrand "math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -66,7 +65,6 @@ func TestWinc(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	mathrand.Seed(time.Now().UnixNano() + int64(GinkgoParallelProcess()))
 	var (
 		present bool
 		err     error


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
It doesn't look `rand.Seed`  is actually needed for running the test.

Context: https://ci.funtime.lol/teams/wg-arp-garden/pipelines/winc-release/jobs/unit-and-integration-tests/builds/91

Backward Compatibility
---------------
Breaking Change? **No**
