### PR TITLE
Fix file/dir creation permissions

### DIFF
--- a/cmd/winc-network/main.go
+++ b/cmd/winc-network/main.go
@@ -69,11 +69,11 @@ func main() {
 		if logFile == "" || logFile == os.DevNull {
 			logWriter = io.Discard
 		} else {
-			if err := os.MkdirAll(filepath.Dir(logFile), 0666); err != nil {
+			if err := os.MkdirAll(filepath.Dir(logFile), 0755); err != nil {
 				return err
 			}
 
-			f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)
+			f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0644)
 			if err != nil {
 				return err
 			}

--- a/cmd/winc/main.go
+++ b/cmd/winc/main.go
@@ -143,12 +143,12 @@ func main() {
 		}
 
 		if !emptyLog(log) {
-			if err := os.MkdirAll(filepath.Dir(log), 0666); err != nil {
+			if err := os.MkdirAll(filepath.Dir(log), 0755); err != nil {
 				return err
 			}
 
 			var err error
-			logFile, err = os.OpenFile(log, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)
+			logFile, err = os.OpenFile(log, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0644)
 			if err != nil {
 				return err
 			}

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -81,11 +81,11 @@ func (h *Helpers) GetContainerState(containerId string) specs.State {
 }
 
 func (h *Helpers) GenerateBundle(bundleSpec specs.Spec, bundlePath string) {
-	ExpectWithOffset(1, os.MkdirAll(bundlePath, 0666)).To(Succeed())
+	ExpectWithOffset(1, os.MkdirAll(bundlePath, 0755)).To(Succeed())
 	config, err := json.Marshal(&bundleSpec)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	configFile := filepath.Join(bundlePath, "config.json")
-	ExpectWithOffset(1, os.WriteFile(configFile, config, 0666)).To(Succeed())
+	ExpectWithOffset(1, os.WriteFile(configFile, config, 0644)).To(Succeed())
 }
 
 func (h *Helpers) CreateContainer(bundleSpec specs.Spec, bundlePath, containerId string) {

--- a/runtime/hcsprocess/process.go
+++ b/runtime/hcsprocess/process.go
@@ -28,7 +28,7 @@ func New(p hcsshim.Process) *Process {
 
 func (p *Process) WritePIDFile(pidFile string) error {
 	if pidFile != "" {
-		if err := os.WriteFile(pidFile, []byte(strconv.FormatInt(int64(p.process.Pid()), 10)), 0666); err != nil {
+		if err := os.WriteFile(pidFile, []byte(strconv.FormatInt(int64(p.process.Pid()), 10)), 0644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Addresses Gosec G306/302/301 errors by fixing file permissions.

On windows only the 0200 and 0400 bits matter, so this doesn't actually change anything to how it functions. However it makes it a lot less scary for tools + people to audit at file permissions.

Backward Compatibility
---------------
Breaking Change? no