### PR TITLE
Use Server struct to create a Server for gosec G114

### DIFF
--- a/integration/winc-network/fixtures/server/server.go
+++ b/integration/winc-network/fixtures/server/server.go
@@ -21,8 +21,12 @@ func main() {
 	})
 	http.HandleFunc("/upload", uploadHandler)
 	http.HandleFunc("/download", downloadHandler)
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: nil,
+	}
 
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+	log.Fatal(server.ListenAndServe())
 }
 
 func uploadHandler(w http.ResponseWriter, r *http.Request) {

--- a/integration/winc/fixtures/goshut/goshut.go
+++ b/integration/winc/fixtures/goshut/goshut.go
@@ -51,6 +51,10 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hi there, I love you!\n")
 	})
-	err := http.ListenAndServe(":8080", nil)
+	server := &http.Server{
+		Addr:    ":8080",
+		Handler: nil,
+	}
+	err := server.ListenAndServe()
 	fmt.Fprintf(os.Stderr, "HTTP server exited: %s\n", err)
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR resolves gosec G114 by using creating a server using the `Server` struct which provides an option specify timeout.


Backward Compatibility
---------------
Breaking Change? **No**
